### PR TITLE
Don't throw error when session not timed out

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ export default (zipkinUrl, _remoteServiceName, _serviceName) =>
         throw new Error("Session timed out");
       } else {
         console.info("Error in middleware API", err);
-        throw err;
       }
       tracer.scoped(() => {
         tracer.setId(traceId);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hotelsoft/zipkin-instrumentation-superagent",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A plugin for superagent that logs traces to zipkin.",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
Execution of code stops and catch blocks written in code doesn't get executed and necessary messages are not displayed on the UI due to throwing of error.